### PR TITLE
Add join support and calling functions on functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .eunit
 *.beam
+.rebar/*

--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -474,6 +474,10 @@ expr2(undefined, _Safe) -> <<"NULL">>;
 expr2(Expr, _Safe) when is_atom(Expr) -> convert(Expr);
 expr2(Expr, Safe) -> expr(Expr, Safe).
 
+param({call, FuncName, []}) ->
+    [convert(FuncName), <<"()">>];
+param({call, FuncName, Params}) ->
+    [convert(FuncName), $(, make_list(Params, fun param/1), $)];
 param({Key, Value}) when is_atom(Key) ->
     [convert(Key), <<" := ">>, encode(Value)];
 param(Key) when is_atom(Key) ->

--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -340,11 +340,16 @@ update(Table, Props, Safe) ->
 update(Table, Props, Where, Safe) when not is_list(Props) ->
     update(Table, [Props], Where, Safe);
 update(Table, Props, Where, Safe) ->
-    S1 = [<<"UPDATE ">>, convert(Table), <<" SET ">>],
+    S1 = case Table of
+        Table when is_tuple(Table) ->
+            join(Table, Safe);
+        _Other ->
+            convert(Table)
+    end,
     S2 = make_list(Props, fun({Field, Val}) ->
         [convert(Field), <<" = ">>, expr(Val, Safe)]
     end),
-    [S1, S2, where(Where, Safe)].
+    [<<"UPDATE ">>, S1, <<" SET ">>, S2, where(Where, Safe)].
 
 delete(Table, Safe) ->
     delete(Table, undefined, undefined, undefined, Safe).

--- a/src/sqerl.erl
+++ b/src/sqerl.erl
@@ -221,12 +221,21 @@ select(Modifier, Fields, Tables, WhereExpr, Extras, Safe) ->
         Expr -> [S5, Expr]
     end.
 
-join({Table, JoinType, Table2, JoinExpr}, Safe) ->
+join({Table, Join, Table2, JoinExpr}, Safe) ->
   [ expr2(Table, Safe),
-    join(JoinType),
+    join(Join),
     expr2(Table2, Safe),
     <<" ON ">>,
     make_list(JoinExpr, fun(Val) -> expr(Val, Safe) end) ];
+join({Table, Joins}, Safe) when is_list(Joins) ->
+  S1 = lists:map(fun({Join, Table2, JoinExpr}) ->
+                     [ join(Join),
+                       expr2(Table2, Safe),
+                       <<" ON ">>,
+                       make_list(JoinExpr, fun(Val) -> expr(Val, Safe)end)
+                     ]
+                 end, Joins),
+  [expr2(Table, Safe), S1];
 join(Table, Safe) ->
   expr2(Table, Safe).
 

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -137,8 +137,8 @@ safe_test_() ->
                                                  {select,distinct,name,{from,gymnast}}}}})
             },
 
-            {<<"SELECT name FROM developer WHERE name IN ((SELECT DISTINCT name FROM gymnast)"
-               "UNION (SELECT name FROM dancer WHERE ((name LIKE 'Mikhail%') OR (country = 'Russia')))"
+            {<<"SELECT name FROM developer WHERE name IN ((SELECT DISTINCT name FROM gymnast) "
+               "UNION (SELECT name FROM dancer WHERE ((name LIKE 'Mikhail%') OR (country = 'Russia'))) "
                "WHERE (name LIKE 'M%') ORDER BY name DESC LIMIT 5, 10)">>,
                 ?_safe_test({select,name,
                                 {from,developer},

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -205,6 +205,9 @@ safe_test_() ->
             {<<"SELECT * FROM foo JOIN bar ON (foo.bar_id = bar.id)">>,
               ?_safe_test({select,'*',{from,{foo,join,bar,{'foo.bar_id','=','bar.id'}}}})
             },
+            {<<"SELECT * FROM foo AS f JOIN bar AS b ON (f.bar_id = b.id)">>,
+              ?_safe_test({select,'*',{from,{{foo,as,f},join,{bar,as,b},{'f.bar_id','=','b.id'}}}})
+            },
             {<<"SELECT * FROM foo JOIN bar ON ((foo.bar_id = bar.id) AND (foo.bar_type = bar.type))">>,
               ?_safe_test({select,'*',{from,{foo,join,bar,[
                                                       {'and', [

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -44,6 +44,16 @@ safe_test_() ->
                                     {where,{'not',{a,'=',5}}}})
             },
 
+            {<<"UPDATE project JOIN client ON (project.client_id = client.id) SET foo = 5">>,
+                ?_safe_test({update,
+                    {project,join,client,{'project.client_id','=','client.id'}},[{foo,5}]})
+            },
+
+            {<<"UPDATE project INNER JOIN client ON (project.client_id = client.id) SET foo = 5">>,
+                ?_safe_test({update,
+                    {project,{inner,join},client,{'project.client_id','=','client.id'}},[{foo,5}]})
+            },
+
             {<<"DELETE FROM project">>,
                 ?_safe_test({delete,project})
             },

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -109,6 +109,14 @@ safe_test_() ->
                 ?_safe_test({select,{call,count,[name]},{from,developer}})
             },
 
+            {<<"SELECT count(name) AS c FROM developer">>,
+                ?_safe_test({select,{{call,count,[name]},as,c},{from,developer}})
+            },
+
+            {<<"SELECT CONCAT('-- [', GROUP_CONCAT(comment.id), ']') AS comments FROM posts">>,
+              ?_safe_test({select,{{call,'CONCAT',["-- [",{call,'GROUP_CONCAT',['comment.id']},"]"]},as,comments},{from,posts}})
+            },
+
             {<<"SELECT last_insert_id()">>,
                 ?_safe_test({select,{call,last_insert_id,[]}})
             },

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -187,8 +187,31 @@ safe_test_() ->
             {<<"SELECT name FROM search_people(age := 18)">>,
                 ?_safe_test({select,name,{from,{call,search_people,[{age, 18}]}}})
             },
-            {<<"SELECT * FROM foo JOIN bar ON foo.bar_id = bar.id">>,
-              ?_safe_test({select,'*',{from,foo,{join,bar,[{'foo.bar_id','=','bar.id'}]}}})
+            {<<"SELECT * FROM foo JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,join,bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo JOIN bar ON ((foo.bar_id = bar.id) AND (foo.bar_type = bar.type))">>,
+              ?_safe_test({select,'*',{from,{foo,join,bar,[
+                                                      {'and', [
+                                                          {'foo.bar_id','=','bar.id'},
+                                                          {'foo.bar_type','=','bar.type'}
+                                                        ]
+                                                      }]}}})
+            },
+            {<<"SELECT * FROM foo LEFT JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,{left,join},bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo INNER JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,{inner,join},bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo RIGHT JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,{right,join},bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo LEFT OUTER JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,{left, outer,join},bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo CROSS JOIN bar ON (foo.bar_id = bar.id)">>,
+              ?_safe_test({select,'*',{from,{foo,{cross,join},bar,{'foo.bar_id','=','bar.id'}}}})
             }
         ]
     }.

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -186,6 +186,9 @@ safe_test_() ->
 
             {<<"SELECT name FROM search_people(age := 18)">>,
                 ?_safe_test({select,name,{from,{call,search_people,[{age, 18}]}}})
+            },
+            {<<"SELECT * FROM foo JOIN bar ON foo.bar_id = bar.id">>,
+              ?_safe_test({select,'*',{from,foo,{join,bar,[{'foo.bar_id','=','bar.id'}]}}})
             }
         ]
     }.

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -223,7 +223,7 @@ safe_test_() ->
               ?_safe_test({select,'*',{from,{foo,{right,join},bar,{'foo.bar_id','=','bar.id'}}}})
             },
             {<<"SELECT * FROM foo LEFT OUTER JOIN bar ON (foo.bar_id = bar.id)">>,
-              ?_safe_test({select,'*',{from,{foo,{left, outer,join},bar,{'foo.bar_id','=','bar.id'}}}})
+              ?_safe_test({select,'*',{from,{foo,{left,outer,join},bar,{'foo.bar_id','=','bar.id'}}}})
             },
             {<<"SELECT * FROM foo CROSS JOIN bar ON (foo.bar_id = bar.id)">>,
               ?_safe_test({select,'*',{from,{foo,{cross,join},bar,{'foo.bar_id','=','bar.id'}}}})

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -227,6 +227,9 @@ safe_test_() ->
             },
             {<<"SELECT * FROM foo CROSS JOIN bar ON (foo.bar_id = bar.id)">>,
               ?_safe_test({select,'*',{from,{foo,{cross,join},bar,{'foo.bar_id','=','bar.id'}}}})
+            },
+            {<<"SELECT * FROM foo JOIN bar ON (foo.bar_id = bar.id) JOIN baz ON (bar.baz_id = baz.id)">>,
+              ?_safe_test({select,'*',{from,{foo,[ {join,bar,{'foo.bar_id','=','bar.id'}},{join,baz,{'bar.baz_id','=','baz.id'}}]}}})
             }
         ]
     }.

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -232,7 +232,8 @@ safe_test_() ->
               ?_safe_test({select,'*',{from,{foo,{cross,join},bar,{'foo.bar_id','=','bar.id'}}}})
             },
             {<<"SELECT * FROM foo JOIN bar ON (foo.bar_id = bar.id) JOIN baz ON (bar.baz_id = baz.id)">>,
-              ?_safe_test({select,'*',{from,{foo,[ {join,bar,{'foo.bar_id','=','bar.id'}},{join,baz,{'bar.baz_id','=','baz.id'}}]}}})
+              ?_safe_test({select,'*',{from,{foo,[ {join,bar,{'foo.bar_id','=','bar.id'}},
+                                                   {join,baz,{'bar.baz_id','=','baz.id'}} ]}}})
             }
         ]
     }.

--- a/test/sqerl_tests.erl
+++ b/test/sqerl_tests.erl
@@ -62,6 +62,11 @@ safe_test_() ->
                 ?_safe_test({delete,project,{a,'=',5}})
             },
 
+            {<<"DELETE FROM project JOIN client ON (project.client_id = client.id) WHERE (client.a = 8)">>,
+                ?_safe_test({delete,{project,join,client,
+                      {'project.client_id','=','client.id'}},{'client.a','=',8}})
+            },
+
             {<<"DELETE FROM project WHERE (a = 5)">>,
                 ?_safe_test({delete,{from,project},{where,{a,'=',5}}})
             },


### PR DESCRIPTION
I know it's been a while since this program has been updated, and I'm not sure if it's still in use. I've found it very useful for working with a legacy schema that doesn't fit into other tool requirements.  Thanks for making it available!

I've added join support for a project I'm working on.

I've also added the ability to call functions on functions for some weird SQL like:

``` sql
SELECT
  CONCAT('[',GROUP_CONCAT(comment.id),']')
FROM posts
JOIN  comments AS comment
  ON comments.post_id = posts.id
GROUP BY posts.id
```
